### PR TITLE
consider switching to doomwiki.org for wiki links/references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a project developed at [Politecnico di Milano](www.polimi.it) by Edoardo Giacomello, [Pier Luca Lanzi](http://www.pierlucalanzi.net/), and [Daniele Loiacono](http://home.deib.polimi.it/loiacono/).
 The project aims at investigating the generation of DOOM levels using Generative Adversarial Networks (GAN).
-We trained two types of GAN on more than 1000 DOOM levels created by the community (available [here](http://doom.wikia.com/wiki/Idgames_archive)) and, then, used them to generate novel levels.
+We trained two types of GAN on more than 1000 DOOM levels created by the community (available [here](https://doomwiki.org/wiki/Idgames_archive)) and, then, used them to generate novel levels.
 
 
 [Report](https://arxiv.org/abs/1804.09154)


### PR DESCRIPTION
Hi, this is a polite, one-time request for you to please consider referencing the community-preferred "Doom Wiki" at doomwiki.org for your citations going forward.

The history: the original Doom Wiki founders decided to leave the commercial wiki host in 2011. The majority of active editors continue to develop the material over at doomwiki.org, but the commercial host refuse to delete the older wiki as a matter of policy, so it remains (and attracts a small number of edits from others).  There's a full writeup here if you are interested: https://doomwiki.org/wiki/Doom_Wiki:Departure_from_Wikia

In general the material on doomwiki is more developed (and I think that is true for this article in question, Idgames_archive).

PR also updates protocol to HTTPS.

Thanks!